### PR TITLE
ci: amarna

### DIFF
--- a/.github/workflows/amarna.yml
+++ b/.github/workflows/amarna.yml
@@ -1,0 +1,25 @@
+name: Amarna analysis
+
+on:
+  push:
+    branches: [master]
+    pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Amarna
+        uses: crytic/amarna-action@v0.1.1
+        id: amarna
+        continue-on-error: true
+        with:
+          sarif: results.sarif
+          target: contracts/
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.amarna.outputs.sarif }}
+          checkout_path: '/github/workspace'


### PR DESCRIPTION
This PR adds [Amarna](https://github.com/crytic/amarna/), a static code analyzer, to the CI.

At times, it has false positives, but generally it's pretty helpful. For example, it detected an unused import of `ACCOUNT_BALANCE_UPPER_BOUND` in `amm.cairo` - but shouldn't it be used in [`set_account_balance` on line 89](https://github.com/CarmineOptions/carmine-protocol/blob/master/contracts/amm.cairo#L89) instead of `POOL_BALANCE_UPPER_BOUND`?

Anyway, I hope it'll actually work and run the first time, GitHub Actions can be a bit finicky to set up :)