### PR TITLE
dev: adding pow10

### DIFF
--- a/contracts/oracles.cairo
+++ b/contracts/oracles.cairo
@@ -1,6 +1,5 @@
 %lang starknet
 
-from starkware.cairo.common.pow import pow
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.bool import TRUE, FALSE
@@ -15,6 +14,7 @@ from contracts.Math64x61 import (
 
 from contracts._cfg import EMPIRIC_ORACLE_ADDRESS, EMPIRIC_AGGREGATION_MODE
 from lib.math_64x61_extended import Math64x61_div_imprecise
+from lib.pow import pow10
 
 # List of available tickers:
 #  https://docs.empiric.network/using-empiric/supported-assets
@@ -36,7 +36,7 @@ func convert_price{range_check_ptr}(price : felt, decimals : felt) -> (price : f
     let (is_convertable) = is_le(price, Math64x61_INT_PART)
     if is_convertable == TRUE:
         let (converted_price) = Math64x61_fromFelt(price)
-        let (pow10xM) = pow(10, decimals)
+        let (pow10xM) = pow10(decimals)
         let (pow10xM_to_64x61) = Math64x61_fromFelt(pow10xM)
         let (price_64x61) = Math64x61_div_imprecise(converted_price, pow10xM_to_64x61)
         return (price_64x61)
@@ -45,7 +45,7 @@ func convert_price{range_check_ptr}(price : felt, decimals : felt) -> (price : f
     let (decimals_1, r) = unsigned_div_rem(decimals, 2)
     let decimals_2 = decimals - decimals_1
 
-    let (pow_10_m1) = pow(10, decimals_1)
+    let (pow_10_m1) = pow10(decimals_1)
     let (c, remainder) = unsigned_div_rem(price, pow_10_m1)
 
     let (a) = convert_price(c, decimals_2)

--- a/lib/math_64x61_extended.cairo
+++ b/lib/math_64x61_extended.cairo
@@ -6,6 +6,8 @@ from starkware.cairo.common.bool import TRUE, FALSE
 
 from contracts.Math64x61 import Math64x61_div, Math64x61_sqrt
 
+const DIV_IMPRECISE_THRESHOLD = 10 ** 30
+
 # Function for iterative division
 func Math64x61_div_imprecise{range_check_ptr}(x : felt, y : felt) -> (res : felt):
     # both x and y are Math64x61
@@ -15,8 +17,7 @@ func Math64x61_div_imprecise{range_check_ptr}(x : felt, y : felt) -> (res : felt
 
     # check whether the number is small enough to
     # be divisible without causing error
-    let (pow_10_to_30) = pow(10, 30)
-    let (is_convertable) = is_le(y, pow_10_to_30)
+    let (is_convertable) = is_le(y, DIV_IMPRECISE_THRESHOLD)
     if is_convertable == TRUE:
         let (res_a) = Math64x61_div(x, y)
         return (res_a)

--- a/lib/pow.cairo
+++ b/lib/pow.cairo
@@ -1,0 +1,86 @@
+%lang starknet
+
+from starkware.cairo.common.registers import get_label_location
+
+func pow10(i) -> (res):
+    let (p) = get_label_location(data)
+    return ([p + i])
+
+    data:
+    dw 10 ** 0
+    dw 10 ** 1
+    dw 10 ** 2
+    dw 10 ** 3
+    dw 10 ** 4
+    dw 10 ** 5
+    dw 10 ** 6
+    dw 10 ** 7
+    dw 10 ** 8
+    dw 10 ** 9
+    dw 10 ** 10
+    dw 10 ** 11
+    dw 10 ** 12
+    dw 10 ** 13
+    dw 10 ** 14
+    dw 10 ** 15
+    dw 10 ** 16
+    dw 10 ** 17
+    dw 10 ** 18
+    dw 10 ** 19
+    dw 10 ** 20
+    dw 10 ** 21
+    dw 10 ** 22
+    dw 10 ** 23
+    dw 10 ** 24
+    dw 10 ** 25
+    dw 10 ** 26
+    dw 10 ** 27
+    dw 10 ** 28
+    dw 10 ** 29
+    dw 10 ** 30
+    dw 10 ** 31
+    dw 10 ** 32
+    dw 10 ** 33
+    dw 10 ** 34
+    dw 10 ** 35
+    dw 10 ** 36
+    dw 10 ** 37
+    dw 10 ** 38
+    dw 10 ** 39
+    dw 10 ** 40
+    dw 10 ** 41
+    dw 10 ** 42
+    dw 10 ** 43
+    dw 10 ** 44
+    dw 10 ** 45
+    dw 10 ** 46
+    dw 10 ** 47
+    dw 10 ** 48
+    dw 10 ** 49
+    dw 10 ** 50
+    dw 10 ** 51
+    dw 10 ** 52
+    dw 10 ** 53
+    dw 10 ** 54
+    dw 10 ** 55
+    dw 10 ** 56
+    dw 10 ** 57
+    dw 10 ** 58
+    dw 10 ** 59
+    dw 10 ** 60
+    dw 10 ** 61
+    dw 10 ** 62
+    dw 10 ** 63
+    dw 10 ** 64
+    dw 10 ** 65
+    dw 10 ** 66
+    dw 10 ** 67
+    dw 10 ** 68
+    dw 10 ** 69
+    dw 10 ** 70
+    dw 10 ** 71
+    dw 10 ** 72
+    dw 10 ** 73
+    dw 10 ** 74
+    dw 10 ** 75
+end


### PR DESCRIPTION
This PR introduces a small optimization. Inspired by Warp's [`pow2`](https://github.com/NethermindEth/warp/blob/develop/warplib/maths/pow2.cairo), it adds a `pow10` function and using it in `convert_price` of `oracles.cairo`. I'm also replacing the 10^30 with a const; the name could be better I guess, feel free to suggest one 🙂

Here's the before and after resource usage when running `test_oracles.cairo`:

```
# before
[PASS] tests/test_oracles.cairo test_Math64x61_div_imprecise (steps=2204, memory_holes=24)
       range_check_builtin=135
[PASS] tests/test_oracles.cairo test_empiric_median_price (steps=1350, memory_holes=24)
       range_check_builtin=76
[PASS] tests/test_oracles.cairo test_convert_price (steps=1299, memory_holes=24)
       range_check_builtin=76


# after
[PASS] tests/test_oracles.cairo test_Math64x61_div_imprecise (steps=1664, memory_holes=15)
       range_check_builtin=126
[PASS] tests/test_oracles.cairo test_empiric_median_price (steps=983, memory_holes=10)
       range_check_builtin=69
[PASS] tests/test_oracles.cairo test_convert_price (steps=932, memory_holes=10)
       range_check_builtin=69

```