### PR TITLE
Add premia when testing get all nonexpr

### DIFF
--- a/tests/itest_specs/basic_round_trip/short_call.cairo
+++ b/tests/itest_specs/basic_round_trip/short_call.cairo
@@ -1,1 +1,1027 @@
-// FIXME: TBD
+%lang starknet
+
+from tests.itest_specs.view_functions.liquidity_pool_basic import LPBasicViewFunctions
+from interface_lptoken import ILPToken
+from interface_liquidity_pool import ILiquidityPool
+from interface_option_token import IOptionToken
+from interface_amm import IAMM
+from types import Math64x61_
+from constants import EMPIRIC_ORACLE_ADDRESS
+
+from openzeppelin.token.erc20.IERC20 import IERC20
+from math64x61 import Math64x61
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+
+namespace ShortCallRoundTrip {
+    func minimal_round_trip_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        // test
+        // -> sell call option
+        // -> withdraw half of the liquidity that was originally deposited from call pool
+        // -> close half of the bought option
+        // -> settle pool
+        // -> settle the option
+        alloc_locals;
+
+        tempvar lpt_call_addr;
+        tempvar lpt_put_addr;
+        tempvar amm_addr;
+        tempvar myusd_addr;
+        tempvar myeth_addr;
+        tempvar admin_addr;
+        tempvar expiry;
+        tempvar opt_long_call_addr;
+        tempvar opt_short_call_addr;
+        
+        let strike_price = Math64x61.fromFelt(1500);
+        %{
+            ids.lpt_call_addr = context.lpt_call_addr
+            ids.lpt_put_addr = context.lpt_put_addr
+            ids.amm_addr = context.amm_addr
+            ids.myusd_addr = context.myusd_address
+            ids.myeth_addr = context.myeth_address
+            ids.admin_addr = context.admin_address
+            ids.expiry = context.expiry_0
+            ids.opt_long_call_addr = context.opt_long_call_addr_0
+            ids.opt_short_call_addr = context.opt_short_call_addr_0
+        %}
+
+        tempvar tmp_address = EMPIRIC_ORACLE_ADDRESS;
+        %{
+            stop_prank_amm = start_prank(context.admin_address, context.amm_addr)
+            stop_mock_current_price = mock_call(
+                ids.tmp_address, "get_spot_median", [1400000000000000000000, 18, 0, 0]  # mock current ETH price at 1400
+            )
+        %}
+
+        // Test initial balance of lp tokens in the account
+        let (bal_eth_lpt_0: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_0.low = 5000000000000000000;
+
+        let (bal_usd_lpt_0: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_0.low = 5000000000;
+
+        // Test unlocked capital in the pools
+        let (call_pool_unlocked_capital_0) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_0 = 11529215046068469760; 
+
+        let (put_pool_unlocked_capital_0) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_0 = 11529215046068469760000;
+
+        // Test initial balance of option tokens in the account
+        let (bal_opt_short_call_tokens_0: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_short_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_short_call_tokens_0.low = 0;
+
+        // Test pool_volatility -> 100
+        let (call_volatility_0) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_0 = 230584300921369395200;
+
+        let (put_volatility_0) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_0 = 230584300921369395200;
+
+        // Test option position from pool's perspective
+        let (opt_long_put_position_0) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_0 = 0;
+        let (opt_short_put_position_0) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_0 = 0;
+        let (opt_long_call_position_0) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_0 = 0;
+        let (opt_short_call_position_0) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_0 = 0;
+
+        // Test lpool_balance
+        let (call_pool_balance_0) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_0 = 11529215046068469760;
+        
+        let (put_pool_balance_0) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_0 = 11529215046068469760000;
+
+        // Test pool_locked_capital
+        let (call_pool_locked_capital_0) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_0=0;
+        let (put_pool_locked_capital_0) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_0=0;
+
+        // test value of pools position
+        let (pools_pos_val_call) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call = 0;
+        
+        let (pools_pos_val_put) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put = 0;
+
+        ///////////////////////////////////////////////////
+        // BUY THE CALL OPTION
+        ///////////////////////////////////////////////////
+
+        %{ stop_warp_1 = warp(1000000000 + 60*60*12, target_contract_address=ids.amm_addr) %}
+
+        let strike_price = Math64x61.fromFelt(1500);
+        let one = Math64x61.fromFelt(1);
+
+        let (premia: Math64x61_) = IAMM.trade_open(
+            contract_address=amm_addr,
+            option_type=0,
+            strike_price=strike_price,
+            maturity=expiry,
+            option_side=1,
+            option_size=one,
+            quote_token_address=myusd_addr,
+            base_token_address=myeth_addr
+        );
+
+        assert premia = 627445539966218; // approx 0.0002 ETH which may sound like way too different from the long premia, but the trade_vol here is 91.6 and the premia is correct
+        // according to calculator
+
+        // Test balance of lp tokens in the account after the option was bought
+        let (bal_eth_lpt_1: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_1.low = 5000000000000000000;
+
+        let (bal_usd_lpt_1: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_1.low = 5000000000;
+
+        // Test amount of myETH in buyers account
+        let (admin_myETH_balance_1: Uint256) = IERC20.balanceOf(
+            contract_address=myeth_addr,
+            account=admin_addr
+        );
+        assert admin_myETH_balance_1.low = 4000263947793208514;
+        // 5 - option_size - fees + premia
+
+        // Test unlocked capital in the pools after the option was bought
+        let (call_pool_unlocked_capital_1) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        // size of the unlocked pool is 5ETH (original) - premium + 0.03*premium
+        assert call_pool_unlocked_capital_1 = 11528606423894702528;
+
+        let (put_pool_unlocked_capital_1) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_1 = 11529215046068469760000;
+
+        // Test balance of option tokens in the account after the option was bought
+        let (bal_opt_short_call_tokens_1: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_short_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_short_call_tokens_1.low = 1000000000000000000;
+
+        
+        // Test pool_volatility 
+        // Vol of 100 for call pool
+        let (call_volatility_1) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_1 = 192153584101141162600;
+
+        // Vol of 83.33 for put pool
+        let (put_volatility_1) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_1 = 230584300921369395200;
+
+        // Test option position
+        // Long put
+        let (opt_long_put_position_1) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_1 = 0;
+
+        // Short Put
+        let (opt_short_put_position_1) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_1 = 0;
+
+        // Long Call
+        let (opt_long_call_position_1) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_1 = 2305843009213693952;
+
+        // Short Call
+        let (opt_short_call_position_1) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_1 = 0;
+
+        // Test lpool_balance
+        // Call Pool
+        let (call_pool_balance_1) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_1=11528606423894702528;
+
+        // Put Pool
+        let (put_pool_balance_1) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_1=11529215046068469760000;
+
+        // Test pool_locked_capital
+        // Call pool
+        let (call_pool_locked_capital_1) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_1=0;
+
+        // Put pool
+        let (put_pool_locked_capital_1) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_1=0;
+
+        // test value of pools position
+        let (pools_pos_val_call_2) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call_2 = 703156361662287;
+        
+        let (pools_pos_val_put_2) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put_2 = 0;
+
+        ///////////////////////////////////////////////////
+        // UPDATE THE ORACLE PRICE
+        ///////////////////////////////////////////////////
+
+        %{
+            stop_mock_current_price()
+            stop_mock_current_price_2 = mock_call(
+                ids.tmp_address, "get_spot_median", [1450000000000000000000, 18, 0, 0]  # mock current ETH price at 1450
+            )
+        %}
+
+        ///////////////////////////////////////////////////
+        // WITHDRAW CAPITAL - WITHDRAW 40% of lp tokens
+        ///////////////////////////////////////////////////
+        let two_eth = Uint256(low = 2000000000000000000, high = 0);
+        ILiquidityPool.withdraw_liquidity(
+            contract_address=amm_addr,
+            pooled_token_addr=myeth_addr,
+            quote_token_address=myusd_addr,
+            base_token_address=myeth_addr,
+            option_type=0,
+            lp_token_amount=two_eth
+        );
+
+        // Test balance of lp tokens in the account after the option was bought and after withdraw
+        let (bal_eth_lpt_2: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_2.low = 3000000000000000000;
+
+        let (bal_usd_lpt_2: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_2.low = 5000000000;
+
+        // Test amount of myETH on option-buyer's account
+        let (admin_myETH_balance_2: Uint256) = IERC20.balanceOf(
+            contract_address=myeth_addr,
+            account=admin_addr
+        );
+        assert admin_myETH_balance_2.low = 6001354552389695119;
+
+        // Test unlocked capital in the pools after the option was bought and after withdraw
+        let (call_pool_unlocked_capital_2) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_2 = 6914405642482689665;
+
+        let (put_pool_unlocked_capital_2) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_2 = 11529215046068469760000;
+
+        // Test balance of option tokens in the account after the option was bought and after withdraw
+        let (bal_opt_short_tokens_2: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_short_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_short_tokens_2.low = 1000000000000000000;
+    
+        // Test pool_volatility 
+        // Call vol -> 125
+        let (call_volatility_2) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_2 = 192153584101141162600;
+
+        // Put vol -> 100
+        let (put_volatility_2) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_2 = 230584300921369395200;
+
+        // Test option position
+        // Long Call
+        let (opt_long_call_position_2) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_2 = 2305843009213693952;
+
+        // Short Call
+        let (opt_short_call_position_2) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_2 = 0;
+
+        // Long Put
+        let (opt_long_put_position_2) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_2 = 0;
+        
+        // Short Put
+        let (opt_short_put_position_2) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_2 = 0;
+        
+        // Test lpool_balance
+        // Call Pool
+        let (call_pool_balance_2) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_2=6914405642482689665;
+
+        // Put pool
+        let (put_pool_balance_2) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_2=11529215046068469760000;
+        
+        // Test pool_locked_capital
+        let (call_pool_locked_capital_2) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_2=0;
+
+        let (put_pool_locked_capital_2) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_2=0;
+
+        // Test unlocked capital
+        let (call_pool_unlocked_capital_3) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_3 = 6914405642482689665;
+
+        let (put_pool_unlocked_capital_3) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_3 = 11529215046068469760000; 
+
+        // test value of pools position
+        let (pools_pos_val_call_3) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call_3 = 9180887569361935;
+        
+        let (pools_pos_val_put_3) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put_3 = 0;
+
+        ///////////////////////////////////////////////////
+        // CLOSE HALF OF THE BOUGHT OPTION
+        ///////////////////////////////////////////////////
+        let two = Math64x61.fromFelt(2);
+        let half = Math64x61.div(one, two);
+
+        let (premia_2: Math64x61_) = IAMM.trade_close(
+            contract_address=amm_addr,
+            option_type=0,
+            strike_price=strike_price,
+            maturity=expiry,
+            option_side=1,
+            option_size=half,
+            quote_token_address=myusd_addr,
+            base_token_address=myeth_addr
+        );
+
+        assert premia_2 = 6665617208432872; 
+
+        // Test balance of lp tokens in the account after the option was bought and after withdraw
+        let (bal_eth_lpt_3: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_3.low = 3000000000000000000;
+
+        let (bal_usd_lpt_3: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_3.low = 5000000000;
+
+        // Test amount of myUSD on option-buyer's account
+        let (admin_myUSD_balance_3: Uint256) = IERC20.balanceOf(
+            contract_address=myusd_addr,
+            account=admin_addr
+        );
+        assert admin_myUSD_balance_3.low = 5000000000;
+
+        // Test amount of myETH on option-buyer's account
+        let (admin_myETH_balance_3: Uint256) = IERC20.balanceOf(
+            contract_address=myeth_addr,
+            account=admin_addr
+        );
+        assert admin_myETH_balance_3.low = 6499865815798077144;
+
+        // Test unlocked capital in the pools after the option was bought and after withdraw
+        let (call_pool_unlocked_capital_3) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_3 = 6917838435345032594;
+
+        let (put_pool_unlocked_capital_3) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_3 = 11529215046068469760000;
+
+        // // Test balance of option tokens in the account after the option was bought and after withdraw
+        let (bal_opt_short_tokens_3: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_short_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_short_tokens_3.low = 500000000000000000;
+
+        // Test pool_volatility 
+        let (call_volatility_3) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_3 = 192153584101141162600; // close option has no impact on volatility
+
+        let (put_volatility_3) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_3 = 230584300921369395200;  
+
+        // Test option position
+        let (opt_long_put_position_3) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_3 = 0;
+        
+        let (opt_short_put_position_3) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_3 = 0;
+        
+        let (opt_long_call_position_3) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_3 =1152921504606846976 ;
+
+        let (opt_short_call_position_3) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_3 = 0;
+
+        // Test lpool_balance
+        let (call_pool_balance_3) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_3=6917838435345032594;
+        
+        let (put_pool_balance_3) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_3=11529215046068469760000;
+
+        // Test pool_locked_capital
+        let (call_pool_locked_capital_3) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_3=0;
+        
+        let (put_pool_locked_capital_3) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_3=0;
+
+        // test value of pools position
+        let (pools_pos_val_call_4) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call_4 = 3232316783144058;
+        
+        let (pools_pos_val_put_4) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put_4 = 0;
+
+        // ///////////////////////////////////////////////////
+        // // SETTLE (EXPIRE) POOL
+        // ///////////////////////////////////////////////////
+
+        %{
+            stop_warp_1()
+            # Set the time 1 second AFTER expiry
+            stop_warp_2 = warp(1000000000 + 60*60*24 + 1, target_contract_address=ids.amm_addr)
+
+            # Mock the terminal price
+            stop_mock_terminal_price = mock_call(
+                ids.tmp_address, "get_last_checkpoint_before", [0, 155000000000, 0, 0, 0]  # mock terminal ETH price at 1550
+            )
+        %}
+
+        ILiquidityPool.expire_option_token_for_pool(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            strike_price=strike_price,
+            maturity=expiry,
+        );
+        ILiquidityPool.expire_option_token_for_pool(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            strike_price=strike_price,
+            maturity=expiry,
+        );
+        ILiquidityPool.expire_option_token_for_pool(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            strike_price=strike_price,
+            maturity=expiry,
+        );
+        ILiquidityPool.expire_option_token_for_pool(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            strike_price=strike_price,
+            maturity=expiry,
+        );
+
+        // Test balance of lp tokens in the account after the option was bought and after withdraw
+        let (bal_eth_lpt_4: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_4.low = 3000000000000000000;
+
+        let (bal_usd_lpt_4: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_4.low = 5000000000;
+
+        // Test amount of myUSD on option-buyer's account
+        let (admin_myUSD_balance_4: Uint256) = IERC20.balanceOf(
+            contract_address=myusd_addr,
+            account=admin_addr
+        );
+        assert admin_myUSD_balance_4.low = 5000000000;
+
+        // Test amount of myETH on option-buyer's account
+        let (admin_myETH_balance_4: Uint256) = IERC20.balanceOf(
+            contract_address=myeth_addr,
+            account=admin_addr
+        );
+        assert admin_myETH_balance_4.low = 6499865815798077144;
+
+
+        // Test unlocked capital in the pools after the option was bought and after withdraw
+        let (call_pool_unlocked_capital_4) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_4 = 6955029451622672819;
+
+        let (put_pool_unlocked_capital_4) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_4 = 11529215046068469760000;
+
+        // Test balance of option tokens in the account after the option was bought and after withdraw
+        let (bal_opt_short_call_tokens_4: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_short_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_short_call_tokens_4.low = 500000000000000000;
+
+        // Test pool_volatility -> 142.85714285714286 put and 100 call
+        let (call_volatility_4) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_4 = 192153584101141162600; // close option has no impact on volatility
+
+        let (put_volatility_4) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_4 = 230584300921369395200; 
+
+        // Test option position
+        let (opt_long_put_position_4) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_4 = 0;
+        
+        let (opt_short_put_position_4) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_4 = 0;
+        
+        let (opt_long_call_position_4) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_4 = 0;
+
+        let (opt_short_call_position_4) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_4 = 0;
+
+        // Test lpool_balance
+        let (call_pool_balance_4) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_4 = 6955029451622672819;
+
+        let (put_pool_balance_4) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_4 = 11529215046068469760000;
+
+        // Test pool_locked_capital
+        let (call_pool_locked_capital_4) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_4 = 0;
+
+        let (put_pool_locked_capital_4) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_4 = 0;
+
+        // test value of pools position
+        let (pools_pos_val_call_5) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call_5 = 0;
+        
+        let (pools_pos_val_put_5) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put_5 = 0;
+
+        ///////////////////////////////////////////////////
+        // SETTLE BOUGHT OPTION
+        ///////////////////////////////////////////////////
+        IAMM.trade_settle(
+            contract_address=amm_addr,
+            option_type=0,
+            strike_price=strike_price,
+            maturity=expiry,
+            option_side=1,
+            option_size=half,
+            quote_token_address=myusd_addr,
+            base_token_address=myeth_addr
+        );
+
+        // Test balance of lp tokens in the account after the option was bought and after withdraw
+        let (bal_eth_lpt_5: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_call_addr,
+            account=admin_addr
+        );
+        assert bal_eth_lpt_5.low = 3000000000000000000;
+
+        let (bal_usd_lpt_5: Uint256) = ILPToken.balanceOf(
+            contract_address=lpt_put_addr,
+            account=admin_addr
+        );
+        assert bal_usd_lpt_5.low = 5000000000;
+
+        // Test amount of myUSD on option-buyer's account
+        let (admin_myUSD_balance_5: Uint256) = IERC20.balanceOf(
+            contract_address=myusd_addr,
+            account=admin_addr
+        );
+        assert admin_myUSD_balance_5.low = 5000000000;
+
+        // Test amount of myETH on option-buyer's account
+        let (admin_myETH_balance_5: Uint256) = IERC20.balanceOf(
+            contract_address=myeth_addr,
+            account=admin_addr
+        );
+        assert admin_myETH_balance_5.low = 6983736783540012627;
+
+
+        // Test unlocked capital in the pools after the option was bought and after withdraw
+        let (call_pool_unlocked_capital_5) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_unlocked_capital_5 = 6955029451622672819;
+
+        // At this moment no additional capital is unlocked
+        // (that happened when the option was settled for the pool)
+        let (put_pool_unlocked_capital_5) = ILiquidityPool.get_unlocked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_unlocked_capital_5 = 11529215046068469760000;
+
+        // Test balance of option tokens in the account after the option was bought and after withdraw
+        let (bal_opt_long_call_tokens_5: Uint256) = IOptionToken.balanceOf(
+            contract_address=opt_long_call_addr,
+            account=admin_addr
+        );
+        assert bal_opt_long_call_tokens_5.low = 0;
+
+        // Test pool_volatility -> 142.85714285714286 put and 100 call
+        let (call_volatility_5) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            maturity=expiry
+        );
+        assert call_volatility_5 = 192153584101141162600; // close option has no impact on volatility
+
+        let (put_volatility_5) = ILiquidityPool.get_pool_volatility(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            maturity=expiry
+        );
+        assert put_volatility_5 = 230584300921369395200; 
+
+        // Test option position
+        let (opt_long_put_position_5) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_put_position_5 = 0;
+        
+        let (opt_short_put_position_5) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_put_position_5 = 0;
+        
+        let (opt_long_call_position_5) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=0,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_long_call_position_5 = 0;
+
+        let (opt_short_call_position_5) = ILiquidityPool.get_pools_option_position(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr,
+            option_side=1,
+            maturity=expiry,
+            strike_price=strike_price
+        );
+        assert opt_short_call_position_5 = 0;
+
+        // Test lpool_balance
+        let (call_pool_balance_5) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_balance_5 = 6955029451622672819;
+
+        let (put_pool_balance_5) = ILiquidityPool.get_lpool_balance(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_balance_5 = 11529215046068469760000;
+
+        // Test pool_locked_capital
+        let (call_pool_locked_capital_5) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_call_addr
+        );
+        assert call_pool_locked_capital_5 = 0;
+        
+        let (put_pool_locked_capital_5) = ILiquidityPool.get_pool_locked_capital(
+            contract_address=amm_addr,
+            lptoken_address=lpt_put_addr
+        );
+        assert put_pool_locked_capital_5 = 0;
+
+        // Test value of pools position
+        let (pools_pos_val_call_6) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_call_addr
+        );
+        assert pools_pos_val_call_6 = 0;
+        
+        let (pools_pos_val_put_6) = ILiquidityPool.get_value_of_pool_position(
+            contract_address = amm_addr,
+            lptoken_address = lpt_put_addr
+        );
+        assert pools_pos_val_put_6 = 0;
+
+        %{
+            # optional, but included for completeness and extensibility
+            stop_prank_amm()
+            stop_mock_current_price_2()
+            stop_mock_terminal_price()
+            stop_warp_1()
+        %}
+
+        return ();
+    }
+}

--- a/tests/itest_specs/view_functions/liquidity_pool_basic.cairo
+++ b/tests/itest_specs/view_functions/liquidity_pool_basic.cairo
@@ -285,7 +285,7 @@ namespace LPBasicViewFunctions {
         // There are 3 call options
         //      two with maturity 1000000000 + 60*60*24
         //      one with maturity 1000000000 - 60*60*24
-        // There are 2 pyt options both with maturity 1000000000 + 60*60*24
+        // There are 2 put options both with maturity 1000000000 + 60*60*24
         // Only the options with maturity 1000000000 + 60*60*24 should show -> 2 calls, 2 puts
 
         alloc_locals;
@@ -334,11 +334,14 @@ namespace LPBasicViewFunctions {
         // *7 because the OptionWithPremia struct has 7 elements
         assert option_call_len = 2*7;
         assert option_put_len = 2*7;
-
+        
         // Calls
         let option_call_side_0 = get_array_element(0, option_call_len, option_call_array);
         let option_call_maturity_0 = get_array_element(1, option_call_len, option_call_array);
         let option_call_strike_0 = get_array_element(2, option_call_len, option_call_array);
+        let option_call_premia_0 = get_array_element(6, option_call_len, option_call_array);
+
+        assert option_call_premia_0 = 2081174898976881;
 
         let (call_option_token_address_0) = ILiquidityPool.get_option_token_address(
             contract_address=amm_addr,
@@ -352,6 +355,11 @@ namespace LPBasicViewFunctions {
         let option_call_side_1 = get_array_element(7, option_call_len, option_call_array);
         let option_call_maturity_1 = get_array_element(8, option_call_len, option_call_array);
         let option_call_strike_1 = get_array_element(9, option_call_len, option_call_array);
+        let option_call_premia_1 = get_array_element(13, option_call_len, option_call_array);
+
+        assert option_call_premia_1 = 608622173767232;
+
+        
         let (call_option_token_address_1) = ILiquidityPool.get_option_token_address(
             contract_address=amm_addr,
             lptoken_address=lpt_call_addr,
@@ -365,6 +373,10 @@ namespace LPBasicViewFunctions {
         let option_put_side_0 = get_array_element(0, option_put_len, option_put_array);
         let option_put_maturity_0 = get_array_element(1, option_put_len, option_put_array);
         let option_put_strike_0 = get_array_element(2, option_put_len, option_put_array);
+        let option_put_premia_0 = get_array_element(6, option_put_len, option_put_array);
+
+        assert option_put_premia_0 = 241695010576185446327;
+        
         let (put_option_token_address_0) = ILiquidityPool.get_option_token_address(
             contract_address=amm_addr,
             lptoken_address=lpt_put_addr,
@@ -377,6 +389,10 @@ namespace LPBasicViewFunctions {
         let option_put_side_1 = get_array_element(7, option_put_len, option_put_array);
         let option_put_maturity_1 = get_array_element(8, option_put_len, option_put_array);
         let option_put_strike_1 = get_array_element(9, option_put_len, option_put_array);
+        let option_put_premia_1 = get_array_element(13, option_put_len, option_put_array);
+
+        assert option_put_premia_1 = 224338456389442822640;     
+
         let (put_option_token_address_1) = ILiquidityPool.get_option_token_address(
             contract_address=amm_addr,
             lptoken_address=lpt_put_addr,

--- a/tests/test_run_integration_tests.cairo
+++ b/tests/test_run_integration_tests.cairo
@@ -9,6 +9,7 @@ from constants import EMPIRIC_ORACLE_ADDRESS
 from tests.itest_specs.setup import deploy_setup
 from tests.itest_specs.basic_round_trip.long_put import LongPutRoundTrip
 from tests.itest_specs.basic_round_trip.long_call import LongCallRoundTrip
+from tests.itest_specs.basic_round_trip.short_call import ShortCallRoundTrip
 from tests.itest_specs.withdraw_liquidity import WithdrawLiquidity
 from tests.itest_specs.trades.series_of_trades import SeriesOfTrades
 from tests.itest_specs.addition_of_lp_tokens import AdditionOfLPTokens
@@ -78,6 +79,19 @@ func test_minimal_round_trip_long_call{syscall_ptr: felt*, pedersen_ptr: HashBui
     // -> settle pool
     // -> settle the option
     LongCallRoundTrip.minimal_round_trip_call();
+    return ();
+}
+
+
+@external
+func test_minimal_round_trip_short_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    // test
+    // -> sell call option
+    // -> withdraw half of the liquidity that was originally deposited from call pool
+    // FIXME: TBD -> close half of the bought option
+    // FIXME: TBD -> settle pool
+    // FIXME: TBD -> settle the option
+    ShortCallRoundTrip.minimal_round_trip_call();
     return ();
 }
 


### PR DESCRIPTION
I couldnt find a bug in this function, mostly due to the fact that i wasn't able to recreate it and the FE currently seems to show correct prices. I added some more checks for the premia when testing the given function. The premia in tests is correct, checked by BS calculator. 