### PR TITLE
Remove Math64x61 from lpool_balance

### DIFF
--- a/contracts/amm.cairo
+++ b/contracts/amm.cairo
@@ -62,7 +62,7 @@ func get_pool_available_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*
 @view
 func is_option_available{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     lptoken_address: Address, option_side: OptionSide, strike_price: Math64x61_, maturity: Int
-) -> (option_availability: felt) {
+) -> (option_availability: Bool) {
     let (option_address) = get_option_token_address(
         lptoken_address=lptoken_address,
         option_side=option_side,
@@ -197,7 +197,7 @@ func close_position{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_chec
     quote_token_address: Address,
     base_token_address: Address,
     lptoken_address: Address
-) -> (premia : felt) {
+) -> (premia : Math64x61_) {
     // All of the unlocking of capital happens inside of the burn function below.
     // Volatility is not updated since closing position is considered as
     // "user does not have opinion on the market state" - this may change down the line

--- a/contracts/fees.cairo
+++ b/contracts/fees.cairo
@@ -7,11 +7,12 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from math64x61 import Math64x61
 
 from constants import FEE_PROPORTION_PERCENT
+from types import Math64x61_
 
 // Fees might be in the future dependent on many different variables and on current state.
 func get_fees{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    value: felt
-) -> (fees: felt) {
+    value: Math64x61_
+) -> (fees: Math64x61_) {
     let three = Math64x61.fromFelt(3);
     let hundred = Math64x61.fromFelt(100);
     let fee_proportion = Math64x61.div(three, hundred);

--- a/contracts/helpers.cairo
+++ b/contracts/helpers.cairo
@@ -19,7 +19,7 @@ from contracts.option_pricing_helpers import (
     add_premia_fees,
     get_new_volatility
 )
-from contracts.types import Option, Math64x61_, Address
+from contracts.types import Option, Math64x61_, Address, OptionType
 
 from starkware.cairo.common.bool import TRUE
 from starkware.cairo.common.math import assert_nn, assert_not_zero, signed_div_rem
@@ -60,11 +60,11 @@ func _get_premia_before_fees{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }(
     option: Option,
-    position_size: felt,
-    option_type: felt,
-    current_volatility: felt,
-    current_pool_balance: felt
-) -> (total_premia_before_fees: felt){
+    position_size: Math64x61_,
+    option_type: OptionType,
+    current_volatility: Math64x61_,
+    current_pool_balance: Math64x61_
+) -> (total_premia_before_fees: Math64x61_){
     // Gets value of position ADJUSTED for fees!!!
 
     alloc_locals;
@@ -141,11 +141,11 @@ func _get_value_of_position{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }(
     option: Option,
-    position_size: felt,
-    option_type: felt,
-    current_volatility: felt,
-    current_pool_balance: felt
-) -> (position_value: felt){
+    position_size: Math64x61_,
+    option_type: OptionType,
+    current_volatility: Math64x61_,
+    current_pool_balance: Math64x61_
+) -> (position_value: Math64x61_){
     // Gets value of position ADJUSTED for fees!!!
 
     alloc_locals;
@@ -211,11 +211,11 @@ func _get_premia_with_fees{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }(
     option: Option,
-    position_size: felt,
-    option_type: felt,
-    current_volatility: felt,
-    current_pool_balance: felt
-) -> (position_value: felt){
+    position_size: Math64x61_,
+    option_type: OptionType,
+    current_volatility: Math64x61_,
+    current_pool_balance: Math64x61_
+) -> (position_value: Math64x61_){
     // Gets premia ADJUSTED for fees!!!
     // FIXME: this is basically the same as _get_value_of_position... only one is from perspective
     // of liquidating position and the other from perspective of entering position

--- a/contracts/liquidity_pool.cairo
+++ b/contracts/liquidity_pool.cairo
@@ -50,11 +50,11 @@ func get_value_of_position{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }(
     option: Option,
-    position_size: felt,
-    option_type: felt,
-    current_volatility: felt,
-    current_pool_balance: felt
-) -> (position_value: felt){
+    position_size: Math64x61_,
+    option_type: OptionType,
+    current_volatility: Math64x61_,
+    current_pool_balance: Math64x61_
+) -> (position_value: Math64x61_){
     let (res) = _get_value_of_position(
         option,
         position_size,

--- a/contracts/option_pricing_helpers.cairo
+++ b/contracts/option_pricing_helpers.cairo
@@ -119,7 +119,7 @@ func get_new_volatility{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     option_type: OptionType,
     side: OptionSide,
     strike_price: Math64x61_,
-    current_pool_balance: felt,
+    current_pool_balance: Math64x61_,
 ) -> (new_volatility: Math64x61_, trade_volatility: Math64x61_) {
     // Calculates two volatilities, one for trade that is happening
     // and the other to update the volatility param (storage_var).

--- a/contracts/options.cairo
+++ b/contracts/options.cairo
@@ -9,7 +9,7 @@
 // wrong result when calculating value of pool's position
 @external
 func remove_option{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    lptoken_address: felt,
+    lptoken_address: Address,
     index: felt
 ) {
     alloc_locals;

--- a/contracts/oracles.cairo
+++ b/contracts/oracles.cairo
@@ -39,7 +39,7 @@ struct Checkpoint {
 
 // Function to convert base 10**decimals number from oracle to base 2**61
 // which is used throughout the AMM
-func convert_price{range_check_ptr}(price: felt, decimals: felt) -> (price: felt) {
+func convert_price{range_check_ptr}(price: felt, decimals: felt) -> (price: Math64x61_) {
     alloc_locals;
 
     let is_convertable = is_le(price, Math64x61.INT_PART);

--- a/contracts/state.cairo
+++ b/contracts/state.cairo
@@ -425,9 +425,8 @@ func append_to_available_options{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
 // inefficiency and wastefulness of this functions doesn't matter, since it will be axed before going to mainnet.
 // used only in removal of an option, which is something that will never happen
 func remove_and_shift_available_options{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    lptoken_address: felt,
+    lptoken_address: Address,
     index: felt
-
 ) {
 
     // Write zero option in provided index
@@ -439,7 +438,7 @@ func remove_and_shift_available_options{syscall_ptr: felt*, pedersen_ptr: HashBu
 }
 
 func shift_available_options{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    lptoken_address: felt,
+    lptoken_address: Address,
     index: felt
 ) {
     alloc_locals;


### PR DESCRIPTION
https://www.notion.so/Drop-Math64x61-as-a-type-in-storage_vars-where-balance-of-position-is-stored-use-Uint256-we-still-663683bb4f584307a4ecd26c1ef7f2fe