### PR TITLE
Polish expire options

### DIFF
--- a/contracts/core_amm/helpers.cairo
+++ b/contracts/core_amm/helpers.cairo
@@ -241,7 +241,7 @@ func split_option_locked_capital{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
     }
 
     // For Put option
-    // User receives option_size * max(0, (strike_price - terminal_price)) in base token for long
+    // User receives option_size * max(0, (strike_price - terminal_price)) in quote quote for long
     // User receives option_size * min(strike_price, terminal_price) for short
     // Summing the two equals option_size * strike_price (=locked capital
     let price_diff = Math64x61.sub(strike_price, terminal_price);

--- a/contracts/core_amm/helpers.cairo
+++ b/contracts/core_amm/helpers.cairo
@@ -241,7 +241,7 @@ func split_option_locked_capital{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*,
     }
 
     // For Put option
-    // User receives option_size * max(0, (strike_price - terminal_price)) in quote quote for long
+    // User receives option_size * max(0, (strike_price - terminal_price)) in quote token for long
     // User receives option_size * min(strike_price, terminal_price) for short
     // Summing the two equals option_size * strike_price (=locked capital
     let price_diff = Math64x61.sub(strike_price, terminal_price);

--- a/contracts/core_amm/liquidity_pool.cairo
+++ b/contracts/core_amm/liquidity_pool.cairo
@@ -561,16 +561,6 @@ func adjust_lpool_balance_and_pool_locked_capital_expired_options{
 
     let (current_lpool_balance: Uint256) = get_lpool_balance(lptoken_address);
     let (current_locked_balance: Uint256) = get_pool_locked_capital(lptoken_address);
-    let (current_pool_position) = get_option_position(
-        lptoken_address, option_side, maturity, strike_price
-    );
-    let current_pool_position_uint256: Uint256 = toUint256_balance(current_pool_position, lpool_underlying_token);
-
-    let new_pool_position = current_pool_position - option_size;
-    with_attr error_message("new_pool_position is negative in adjust_lpool_balance_and_pool_locked_capital_expired_options") {
-        assert_nn(new_pool_position);
-    }
-    set_option_position(lptoken_address, option_side, maturity, strike_price, new_pool_position);
 
     if (option_side == TRADE_SIDE_LONG) {
         // Pool is LONG
@@ -610,6 +600,10 @@ func adjust_lpool_balance_and_pool_locked_capital_expired_options{
         // The long value is left in the pool for the long owner to collect it.
 
         let (new_lpool_balance: Uint256) = uint256_sub(current_lpool_balance, long_value_uint256);
+        with_attr error_message("Not enough capital in the pool - new_lpool_balance negative") {
+            let (res1: felt) = uint256_signed_le(long_value_uint256, current_lpool_balance);
+            assert res1 = 1;
+        }
 
         // Substracting the combination of long and short rather than separately because of rounding error
         // More specifically transfering the combo to uint256 rather than separate values because
@@ -619,6 +613,10 @@ func adjust_lpool_balance_and_pool_locked_capital_expired_options{
         assert carry = 0;
 
         let (new_locked_balance: Uint256) = uint256_sub(current_locked_balance, long_plus_short_value);
+        with_attr error_message("Not enough capital in the pool - new_locked_balance negative") {
+            let (res2: felt) = uint256_signed_le(long_plus_short_value, current_locked_balance);
+            assert res2 = 1;
+        }
 
         with_attr error_message("Not enough capital in the pool") {
             // This will never happen since the capital to pay the users is always locked.
@@ -700,23 +698,33 @@ func expire_option_token_for_pool{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
     local term = terminal_price;
     with_attr error_message("unable to split_option_locked_capital in expire_option_token_for_pool optsize {optsize}, optsize64 {optisize64} strike {str} term {term}"){
     let (long_value, short_value)  = split_option_locked_capital(
-        option_type, option_side, option_size_m64x61, strike_price, terminal_price
-    );
+            option_type, option_side, option_size_m64x61, strike_price, terminal_price
+        );
     }
 
     // Adjusts only the lpool_balance and pool_locked_capital storage_vars
     with_attr error_message("unable to adjust_lpool_balance_and_pool_locked_capital_expired_options in expire_option_token_for_pool"){
-    adjust_lpool_balance_and_pool_locked_capital_expired_options(
-        lptoken_address=lptoken_address,
-        long_value=long_value,
-        short_value=short_value,
-        option_size=option_size,
-        option_side=option_side,
-        maturity=maturity,
-        strike_price=strike_price
-    );
+        adjust_lpool_balance_and_pool_locked_capital_expired_options(
+            lptoken_address=lptoken_address,
+            long_value=long_value,
+            short_value=short_value,
+            option_size=option_size,
+            option_side=option_side,
+            maturity=maturity,
+            strike_price=strike_price
+        );
     }
 
+    let (current_pool_position) = get_option_position(
+        lptoken_address, option_side, maturity, strike_price
+    );
+
+    let new_pool_position = current_pool_position - option_size;
+    with_attr error_message("new_pool_position is negative in expire_option_token_for_pool") {
+        assert_nn(new_pool_position);
+        // New pool position should be zero
+        // assert_nn(0 - new_pool_position);
+    }
     // We have to adjust the pools option position too.
     set_option_position(lptoken_address, option_side, maturity, strike_price, 0);
 

--- a/contracts/core_amm/liquidity_pool.cairo
+++ b/contracts/core_amm/liquidity_pool.cairo
@@ -698,9 +698,9 @@ func expire_option_token_for_pool{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
     local term = terminal_price;
     with_attr error_message("unable to split_option_locked_capital in expire_option_token_for_pool optsize {optsize}, optsize64 {optisize64} strike {str} term {term}"){
     let (long_value, short_value)  = split_option_locked_capital(
-            option_type, option_side, option_size_m64x61, strike_price, terminal_price
-        );
-    }
+        option_type, option_side, option_size_m64x61, strike_price, terminal_price
+    );
+}
 
     // Adjusts only the lpool_balance and pool_locked_capital storage_vars
     with_attr error_message("unable to adjust_lpool_balance_and_pool_locked_capital_expired_options in expire_option_token_for_pool"){

--- a/contracts/core_amm/liquidity_pool.cairo
+++ b/contracts/core_amm/liquidity_pool.cairo
@@ -722,8 +722,7 @@ func expire_option_token_for_pool{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*
     let new_pool_position = current_pool_position - option_size;
     with_attr error_message("new_pool_position is negative in expire_option_token_for_pool") {
         assert_nn(new_pool_position);
-        // New pool position should be zero
-        // assert_nn(0 - new_pool_position);
+        assert_le(option_size, current_pool_position);
     }
     // We have to adjust the pools option position too.
     set_option_position(lptoken_address, option_side, maturity, strike_price, 0);

--- a/contracts/core_amm/options.cairo
+++ b/contracts/core_amm/options.cairo
@@ -1027,9 +1027,6 @@ func expire_option_token{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
         let short_value_uint256 = toUint256_balance(short_value, currency_address);
     }
     
-    // Validate that the user is not burning more than he/she has.
-    let (pool_definition) = get_pool_definition_from_lptoken_address(lptoken_address);
-    let base_address = pool_definition.base_token_address;
     with_attr error_message("expire_option_token failed when converting option_size to uint") {
         let option_size_uint256 = intToUint256(option_size);
     }

--- a/contracts/core_amm/options.cairo
+++ b/contracts/core_amm/options.cairo
@@ -986,7 +986,7 @@ func expire_option_token{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
         );
     }
     // Check that the pool's position was expired correctly
-    let (current_pool_position_2) = get_option_position(
+    let (current_pool_position_2) = get_option_position( // FIXME this is called twice in the happy case
         lptoken_address,TRADE_SIDE_SHORT, maturity, strike_price
     );
     with_attr error_message(


### PR DESCRIPTION
Basically only simple edits, also moved setting pool from adjust_lpool_balance_and_pool_locked_capital_expired_options to expire_opt_for_pool, also please check line 726 in liq_pool.cairo. Should that check be uncommented or removed(do we care if there is little position left)? 